### PR TITLE
fix: 输出文本区块时保证区块已经初始化

### DIFF
--- a/src/renderer/src/services/messageStreaming/callbacks/textCallbacks.ts
+++ b/src/renderer/src/services/messageStreaming/callbacks/textCallbacks.ts
@@ -14,32 +14,42 @@ interface TextCallbacksDependencies {
   getCitationBlockId: () => string | null
 }
 
+
+
 export const createTextCallbacks = (deps: TextCallbacksDependencies) => {
   const { blockManager, getState, assistantMsgId, getCitationBlockId } = deps
 
   // 内部维护的状态
   let mainTextBlockId: string | null = null
 
+  // 保证文本块初始化完成
+  async function ensureMainTextBlockInitialized() {
+  if (blockManager.hasInitialPlaceholder) {
+          const changes = {
+            type: MessageBlockType.MAIN_TEXT,
+            content: '',
+            status: MessageBlockStatus.STREAMING
+          }
+          mainTextBlockId = blockManager.initialPlaceholderBlockId!
+          blockManager.smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
+        } else if (!mainTextBlockId) {
+          const newBlock = createMainTextBlock(assistantMsgId, '', {
+            status: MessageBlockStatus.STREAMING
+          })
+          mainTextBlockId = newBlock.id
+          await blockManager.handleBlockTransition(newBlock, MessageBlockType.MAIN_TEXT)
+        }
+  }
+
   return {
     onTextStart: async () => {
-      if (blockManager.hasInitialPlaceholder) {
-        const changes = {
-          type: MessageBlockType.MAIN_TEXT,
-          content: '',
-          status: MessageBlockStatus.STREAMING
-        }
-        mainTextBlockId = blockManager.initialPlaceholderBlockId!
-        blockManager.smartBlockUpdate(mainTextBlockId, changes, MessageBlockType.MAIN_TEXT, true)
-      } else if (!mainTextBlockId) {
-        const newBlock = createMainTextBlock(assistantMsgId, '', {
-          status: MessageBlockStatus.STREAMING
-        })
-        mainTextBlockId = newBlock.id
-        await blockManager.handleBlockTransition(newBlock, MessageBlockType.MAIN_TEXT)
-      }
+      await ensureMainTextBlockInitialized();
     },
 
     onTextChunk: async (text: string) => {
+      if (mainTextBlockId === null) {
+        await ensureMainTextBlockInitialized();
+      }
       const citationBlockId = getCitationBlockId()
       const citationBlockSource = citationBlockId
         ? (getState().messageBlocks.entities[citationBlockId] as CitationMessageBlock).response?.source


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #8738

### Why we need it and why it was done in this way

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note

```
